### PR TITLE
Replace deprecated method

### DIFF
--- a/src/LaravelApiExplorer.php
+++ b/src/LaravelApiExplorer.php
@@ -3,6 +3,7 @@
 namespace NetoJose\LaravelApiExplorer;
 
 use Route;
+use ReflectionClass;
 use ReflectionParameter;
 use ReflectionMethod;
 use Illuminate\Support\Str;
@@ -169,7 +170,9 @@ class LaravelApiExplorer
 
         if (count($params)) {
             $parameter = new ReflectionParameter([$controller, $method], 0);
-            $requestClass = $parameter->getClass();
+            $requestClass = $parameter->getType() && !$parameter->getType()->isBuiltin()
+                ? new ReflectionClass($parameter->getType()->getName())
+                : null;
         }
 
         return $requestClass;


### PR DESCRIPTION
`getClass` has been deprecated in PHP8. I replaced it with the suggested solution.