### PR TITLE
Allow for iterable match config

### DIFF
--- a/src/LaravelApiExplorer.php
+++ b/src/LaravelApiExplorer.php
@@ -63,7 +63,15 @@ class LaravelApiExplorer
     {
         $filtered = [];
 
-        $match = trim(config('laravelapiexplorer.match'), '/');
+        $match = value(config('laravelapiexplorer.match'), function($match) {
+          if (is_iterable($match)) {
+            return array_map(function ($match) {
+              return trim($match, '/');
+            }, $match);
+          } else {
+            return trim($match, '/');
+          }
+        });
         $ignoreList = collect(config('laravelapiexplorer.ignore'));
         $ignoreList->push('laravelapiexplorer.view');
         $ignoreList->push('laravelapiexplorer.info');


### PR DESCRIPTION
The `Str::is()` method is used for testing the matches against URIs and route names; `Str::is($match)` is allowed to be either a string or an iterable. By modifying the LaravelApiExplorer::filterRoutes() method to filter the config `laravelapiexplorer.match` as if it could be a string or an iterable, we thereby allow for using an iterable in the configuration. This allows for more control over which routes appear in the explorer, without having to use the ignore configuration.